### PR TITLE
Add basic CI jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: build
 fmt:
 	go fmt ./...
 
+verify-fmt:
+	hack/verify-gofmt.sh
+
 vet:
 	go vet ./pkg/... ./cmd/...
 
@@ -27,4 +30,4 @@ clean:
 	cd capi && \
 	rm -rf *.a *.la *.lo *.o .libs/ libvirtblocks.h
 
-.PHONY: all fmt clean build vet
+.PHONY: all fmt clean build vet verify-fmt

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: build
 fmt:
 	go fmt ./...
 
+vet:
+	go vet ./pkg/... ./cmd/...
+
 build:
 	cd capi && \
 	go build -buildmode c-archive -o libvirtblocks.a capi.go && \
@@ -24,4 +27,4 @@ clean:
 	cd capi && \
 	rm -rf *.a *.la *.lo *.o .libs/ libvirtblocks.h
 
-.PHONY: all fmt clean build
+.PHONY: all fmt clean build vet

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+diff=$(gofmt -d -e ./ 2>&1) || true
+if [[ -n "${diff}" ]]; then
+  echo "${diff}" >&2
+  echo >&2
+  echo "Run 'make fmt'" >&2
+  exit 1
+fi

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.12.5
+
+RUN apt-get update && apt-get install -y libtool libtool-bin


### PR DESCRIPTION
* Verify that golang code compiles properly.
* Do basic code analysis with `go vet`.
* Verify that golang code is formatted properly.
* Add the Dockerfile which is used in CI to test if virtblocks can be built.

The PR on prow for enabling CI for virtblocks: https://github.com/kubevirt/project-infra/pull/153

