### PR TITLE
Run make fmt for rust sources

### DIFF
--- a/src/capi/mod.rs
+++ b/src/capi/mod.rs
@@ -2,15 +2,15 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
 
-use super::util;
 use super::devices;
+use super::util;
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_util_build_file_name(file_name: *mut *mut c_char,
-                                   base: *const c_char,
-                                   ext: *const c_char) -> i32
-{
+pub extern "C" fn virtblocks_util_build_file_name(
+    file_name: *mut *mut c_char,
+    base: *const c_char,
+    ext: *const c_char,
+) -> i32 {
     if base.is_null() || ext.is_null() || file_name.is_null() {
         return -1;
     }
@@ -27,14 +27,12 @@ fn virtblocks_util_build_file_name(file_name: *mut *mut c_char,
 }
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_devices_memballoon_new() -> *mut devices::Memballoon {
+pub extern "C" fn virtblocks_devices_memballoon_new() -> *mut devices::Memballoon {
     Box::into_raw(Box::new(devices::Memballoon::new()))
 }
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_devices_memballoon_free(c_memballoon: *mut devices::Memballoon) {
+pub extern "C" fn virtblocks_devices_memballoon_free(c_memballoon: *mut devices::Memballoon) {
     let _rust_memballoon = unsafe {
         assert!(!c_memballoon.is_null());
         Box::from_raw(c_memballoon)
@@ -42,10 +40,10 @@ fn virtblocks_devices_memballoon_free(c_memballoon: *mut devices::Memballoon) {
 }
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_devices_memballoon_set_model(c_memballoon: *mut devices::Memballoon,
-                                           model: devices::MemballoonModel)
-{
+pub extern "C" fn virtblocks_devices_memballoon_set_model(
+    c_memballoon: *mut devices::Memballoon,
+    model: devices::MemballoonModel,
+) {
     let rust_memballoon = unsafe {
         assert!(!c_memballoon.is_null());
         &mut *c_memballoon
@@ -55,9 +53,9 @@ fn virtblocks_devices_memballoon_set_model(c_memballoon: *mut devices::Memballoo
 }
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_devices_memballoon_get_model(c_memballoon: *const devices::Memballoon) -> devices::MemballoonModel
-{
+pub extern "C" fn virtblocks_devices_memballoon_get_model(
+    c_memballoon: *const devices::Memballoon,
+) -> devices::MemballoonModel {
     let rust_memballoon = unsafe {
         assert!(!c_memballoon.is_null());
         &*c_memballoon
@@ -67,8 +65,9 @@ fn virtblocks_devices_memballoon_get_model(c_memballoon: *const devices::Memball
 }
 
 #[no_mangle]
-pub extern "C"
-fn virtblocks_devices_memballoon_to_str(c_memballoon: *const devices::Memballoon) -> *mut c_char {
+pub extern "C" fn virtblocks_devices_memballoon_to_str(
+    c_memballoon: *const devices::Memballoon,
+) -> *mut c_char {
     let rust_memballoon = unsafe {
         assert!(!c_memballoon.is_null());
         &*c_memballoon
@@ -76,8 +75,6 @@ fn virtblocks_devices_memballoon_to_str(c_memballoon: *const devices::Memballoon
 
     let rust_ret = rust_memballoon.to_str();
 
-    let c_ret = unsafe {
-        libc::strdup(CString::new(rust_ret).unwrap().as_ptr())
-    };
+    let c_ret = unsafe { libc::strdup(CString::new(rust_ret).unwrap().as_ptr()) };
     c_ret
 }

--- a/src/devices/memballoon.rs
+++ b/src/devices/memballoon.rs
@@ -12,7 +12,6 @@ pub struct Memballoon {
 }
 
 impl Memballoon {
-
     pub fn new() -> Self {
         Self {
             model: MemballoonModel::VirtIO,
@@ -33,14 +32,14 @@ impl Memballoon {
         match self.model {
             MemballoonModel::VirtIO => {
                 ret.push_str("virtio-memballoon");
-            },
+            }
             MemballoonModel::VirtIONonTransitional => {
                 ret.push_str("virtio-memballoon-non-transitional");
-            },
+            }
             MemballoonModel::VirtIOTransitional => {
                 ret.push_str("virtio-memballoon-transitional");
-            },
-            MemballoonModel::None => {},
+            }
+            MemballoonModel::None => {}
         }
 
         ret

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,4 +1,4 @@
 mod memballoon;
 
-pub use memballoon::MemballoonModel;
 pub use memballoon::Memballoon;
+pub use memballoon::MemballoonModel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod util;
 pub mod devices;
+pub mod util;
 
 mod capi;


### PR DESCRIPTION
The rule was added, so now all sources should be adjusted so that in the future
the formatting can be enforced.  And also be nicer to edit if your editor
supports formatting the code with rustfmt before saving.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>