### PR TITLE
rust: spell out the MemBalloon enum type

### DIFF
--- a/rust/native/src/devices/memballoon.rs
+++ b/rust/native/src/devices/memballoon.rs
@@ -12,7 +12,7 @@ pub enum MemballoonModel {
 
 impl Default for MemballoonModel {
     fn default() -> Self {
-        Self::None
+        MemballoonModel::None
     }
 }
 


### PR DESCRIPTION
Compilation fails for me with rust-1.36.0-1.fc29.x86_64:
error: enum variants on type aliases are experimental
  --> src/devices/memballoon.rs:15:9
   |
15 |         Self::None
   |         ^^^^^^^^^^

Fixes: 5321fa4d90b17c50df00083f326ce660bb443208
Signed-off-by: Ján Tomko <jtomko@redhat.com>