### PR TITLE
build: Remove Go-only rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 
 all: build
 
-build: build-subdirs-$(VIRTBLOCKS_LANGUAGE)
-clean: clean-subdirs-$(VIRTBLOCKS_LANGUAGE)
-test: test-subdirs-$(VIRTBLOCKS_LANGUAGE)
-run-examples: run-examples-subdirs-$(VIRTBLOCKS_LANGUAGE)
-fmt: fmt-subdirs-$(VIRTBLOCKS_LANGUAGE)
-verify-fmt: verify-fmt-subdirs-$(VIRTBLOCKS_LANGUAGE)
-vet: vet-subdirs-$(VIRTBLOCKS_LANGUAGE)
+build: build-subdirs
+clean: clean-subdirs
+test: test-subdirs
+run-examples: run-examples-subdirs
+fmt: fmt-subdirs
+verify-fmt: verify-fmt-subdirs
+vet: vet-subdirs
 
 .PHONY: all build clean test run-examples fmt verify-fmt vet
 
@@ -22,22 +22,7 @@ SUBDIRS = \
 	go/rust \
 	$(NULL)
 
-%-subdirs-:
+%-subdirs:
 	for d in $(SUBDIRS); do \
-		$(MAKE) -C $$d $(subst -subdirs-,,$@) || exit 1; \
-	done
-
-# These only operate on the Go code that can be compiled without having
-# a Rust compiler installed, and are kept around for compatibility with
-# the existing CI setup. Once we update that, we'll be able to get rid
-# of them.
-
-SUBDIRS_GOLANG = \
-	go/native \
-	c/go \
-	$(NULL)
-
-%-subdirs-golang:
-	for d in $(SUBDIRS_GOLANG); do \
-		$(MAKE) -C $$d $(subst -subdirs-golang,,$@) || exit 1; \
+		$(MAKE) -C $$d $(subst -subdirs,,$@) || exit 1; \
 	done


### PR DESCRIPTION
The KubeVirt CI has been updated to call the naked targets,
so these compatibility rules are no longer needed.