### PR TITLE
Test everything in travis, not just Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,17 @@ rust:
   - stable
   - beta
   - nightly
-env:
-  - CARGO_DIR=rust/native
-  - CARGO_DIR=c/rust
 install:
   - rustup component add rustfmt clippy
-before_script:
-  - cd $CARGO_DIR
+  # All go version management in Travis is done using gimme (just like rustup,
+  # nvm, etc.) and it is installed by default on travis' images.  We need this
+  # to get newer go than 1.11, which is the default in all images in travis.
+  - eval $(gimme stable)
 script:
-  - cargo build $CARGO_PROFILE
-  - cargo test $CARGO_PROFILE
-  - cargo check $CARGO_PROFILE
-  - cargo clippy $CARGO_PROFILE
-  - cargo fmt -- --check
+  - make build
+  - make test
+  - make vet
+  - make verify-fmt
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ rust:
   - beta
   - nightly
 env:
-  - CARGO_DIR=rust/native CARGO_PROFILE=
-  - CARGO_DIR=rust/native CARGO_PROFILE=--release
-  - CARGO_DIR=c/rust CARGO_PROFILE=
-  - CARGO_DIR=c/rust CARGO_PROFILE=--release
+  - CARGO_DIR=rust/native
+  - CARGO_DIR=c/rust
 install:
   - rustup component add rustfmt clippy
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 sudo: false
 cache: cargo
+# We are doing just macOS build because linux builds are tested in prow
+os: osx
 rust:
   - stable
   - beta
@@ -10,6 +12,7 @@ install:
   # All go version management in Travis is done using gimme (just like rustup,
   # nvm, etc.) and it is installed by default on travis' images.  We need this
   # to get newer go than 1.11, which is the default in all images in travis.
+  - brew install gimme
   - eval $(gimme stable)
 script:
   - make build


### PR DESCRIPTION
This is based on #8 because it gets rid of libtool, which we would have to install otherwise.