### PR TITLE
license: Adopt the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019 Red Hat, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -57,6 +57,11 @@ make sense in that context.
 The top-level `Makefile` provides a convenient way to build and test
 all sub-projects at once.
 
+## License
+
+Virt Blocks is distributed under the terms of the MIT License. See
+the `LICENSE` file for details.
+
 ## Contributing
 
 GitHub pull requests and GitLab merge requests are both accepted, but

--- a/c/go/capi.c
+++ b/c/go/capi.c
@@ -1,3 +1,11 @@
+/* Virt Blocks
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This software is distributed under the terms of the MIT License.
+ * See the LICENSE file in the top level directory for details.
+ */
+
 #include "libvirtblocks_c_go.h"
 #include "virtblocks.h"
 

--- a/c/go/capi.go
+++ b/c/go/capi.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package main
 
 import "C"

--- a/c/go/virtblocks.h
+++ b/c/go/virtblocks.h
@@ -1,3 +1,11 @@
+/* Virt Blocks
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This software is distributed under the terms of the MIT License.
+ * See the LICENSE file in the top level directory for details.
+ */
+
 int virtblocks_util_build_file_name(char **file_name,
                                     const char *base,
                                     const char *ext);

--- a/c/rust/src/lib.rs
+++ b/c/rust/src/lib.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::not_unsafe_ptr_arg_deref))]
 
 use std::ffi::CStr;

--- a/c/rust/virtblocks.h
+++ b/c/rust/virtblocks.h
@@ -1,3 +1,11 @@
+/* Virt Blocks
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This software is distributed under the terms of the MIT License.
+ * See the LICENSE file in the top level directory for details.
+ */
+
 int virtblocks_util_build_file_name(char **fileName,
                                     const char *base,
                                     const char *ext);

--- a/go/native/examples/native/main.go
+++ b/go/native/examples/native/main.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package main
 
 import (

--- a/go/native/pkg/devices/memballoon.go
+++ b/go/native/pkg/devices/memballoon.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package devices
 
 type MemballoonModel int

--- a/go/native/pkg/util/util.go
+++ b/go/native/pkg/util/util.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package util
 
 func BuildFileName(base string, ext string) string {

--- a/go/rust/examples/bindings/main.go
+++ b/go/rust/examples/bindings/main.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package main
 
 import (

--- a/go/rust/pkg/devices/memballoon.go
+++ b/go/rust/pkg/devices/memballoon.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package devices
 
 // #cgo CPPFLAGS: -I../../../../c/rust/

--- a/go/rust/pkg/util/util.go
+++ b/go/rust/pkg/util/util.go
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 package util
 
 // #cgo CPPFLAGS: -I../../../../c/rust/

--- a/rust/native/examples/native/main.rs
+++ b/rust/native/examples/native/main.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 use virtblocks_rust_native::devices;
 use virtblocks_rust_native::util;
 

--- a/rust/native/src/devices/memballoon.rs
+++ b/rust/native/src/devices/memballoon.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 use std::fmt;
 
 /// Type of balloon device

--- a/rust/native/src/devices/mod.rs
+++ b/rust/native/src/devices/mod.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 //! # Virt Devices
 
 mod memballoon;

--- a/rust/native/src/lib.rs
+++ b/rust/native/src/lib.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 //! # Virt Blocks
 //!
 //! `virtblocks` is a collection of utilities which can be either

--- a/rust/native/src/util.rs
+++ b/rust/native/src/util.rs
@@ -1,3 +1,10 @@
+// Virt Blocks
+//
+// Copyright (C) 2019 Red Hat, Inc.
+//
+// This software is distributed under the terms of the MIT License.
+// See the LICENSE file in the top level directory for details.
+
 /// Build a filename (as a simple FFI test)
 ///
 /// # Examples


### PR DESCRIPTION
We should have an explicit license, and MIT seems like a good choice because it's compatible both with the Apache 2.0 License (KubeVirt) and the LGPL 2.1 (libvirt).

Tagging all current contributors: @rmohr, @nertpinx, @janotomko, @elmarco so that they can express their opinion. If you agree with adopting the MIT License, please comment on this PR with your Signed-off-by tag.